### PR TITLE
Fix Raycast reporting false positives

### DIFF
--- a/source/Jitter/Collision/GJKCollide.cs
+++ b/source/Jitter/Collision/GJKCollide.cs
@@ -346,6 +346,12 @@ namespace Jitter.Collision
                     else
                     {
                         lambda = lambda - VdotW / VdotR;
+                        if (lambda > 1)
+                        {
+                            //If we've gone beyond where the ray can reach, there's obviously no hit.
+                            simplexSolverPool.GiveBack(simplexSolver);
+                            return false;
+                        }
                         JVector.Multiply(ref r, lambda, out x);
                         JVector.Add(ref origin, ref x, out x);
                         JVector.Subtract(ref x, ref p, out w);


### PR DESCRIPTION
Fix Raycast reporting false positives for rays that cross a bounding box but not the shape that is inside it, thanks to analyzing BEPU Physics raycasting source code.

The code used from BEPU is here:
https://github.com/bepu/bepuphysics1/blob/e0438719412e2eab8683d5ca65c1b0bb0e9b177a/BEPUphysics/CollisionTests/CollisionAlgorithms/GJK/GJKToolbox.cs#L347

This should or may fix this issue:
https://github.com/mattleibow/jitterphysics/issues/19