### PR TITLE
Patch 1

### DIFF
--- a/source/Jitter/Collision/GJKCollide.cs
+++ b/source/Jitter/Collision/GJKCollide.cs
@@ -346,6 +346,12 @@ namespace Jitter.Collision
                     else
                     {
                         lambda = lambda - VdotW / VdotR;
+                        if (lambda > 1)
+                        {
+                            //If we've gone beyond where the ray can reach, there's obviously no hit.
+                            simplexSolverPool.GiveBack(simplexSolver);
+                            return false;
+                        }
                         JVector.Multiply(ref r, lambda, out x);
                         JVector.Add(ref origin, ref x, out x);
                         JVector.Subtract(ref x, ref p, out w);

--- a/source/Jitter/Collision/GJKCollide.cs
+++ b/source/Jitter/Collision/GJKCollide.cs
@@ -334,6 +334,11 @@ namespace Jitter.Collision
 
                 float VdotW = JVector.Dot(ref v, ref w);
 
+                if (lambda > 1.0f)
+                {
+                    return false;
+                }
+
                 if (VdotW > 0.0f)
                 {
                     VdotR = JVector.Dot(ref v, ref r);
@@ -346,12 +351,6 @@ namespace Jitter.Collision
                     else
                     {
                         lambda = lambda - VdotW / VdotR;
-                        if (lambda > 1)
-                        {
-                            //If we've gone beyond where the ray can reach, there's obviously no hit.
-                            simplexSolverPool.GiveBack(simplexSolver);
-                            return false;
-                        }
                         JVector.Multiply(ref r, lambda, out x);
                         JVector.Add(ref origin, ref x, out x);
                         JVector.Subtract(ref x, ref p, out w);
@@ -367,13 +366,16 @@ namespace Jitter.Collision
 
             // Giving back the fraction like this *should* work
             // but is inaccurate against large objects:
-            // fraction = lambda;
+            fraction = lambda;
 
+            /*
+            // Fraction will be used because calculating fraction using this code results in random flickering of the hit point along the ray.
             JVector p1, p2;
             simplexSolver.ComputePoints(out p1, out p2);
 
             p2 = p2 - origin;
             fraction = p2.Length() / direction.Length();
+            */
 
             #endregion
 


### PR DESCRIPTION
Fix Raycast reporting false positives for rays that cross a bounding box but not the shape that is inside it, thanks to analyzing BEPU Physics raycasting source code.

The code used from BEPU is here:
https://github.com/bepu/bepuphysics1/blob/e0438719412e2eab8683d5ca65c1b0bb0e9b177a/BEPUphysics/CollisionTests/CollisionAlgorithms/GJK/GJKToolbox.cs#L347

This should or may fix this issue:
#19

This PR was originally https://github.com/mattleibow/jitterphysics/pull/29 but after removing the repository I encountered this bug https://github.com/isaacs/github/issues/168 so I closed the previous PR to be able to update it. Here are the changes:

After reviewing https://github.com/bulletphysics/bullet3/blob/cdd56e46411527772711da5357c856a90ad9ea67/src/BulletCollision/NarrowPhaseCollision/btSubSimplexConvexCast.cpp I was able to fix the raycast reporting wrong distances randomly by using `lambda` as `fraction` directly instead of calculating it.